### PR TITLE
Fix webapp port: revert back to 8000 for compatibility with bjorn.ser…

### DIFF
--- a/webapp.py
+++ b/webapp.py
@@ -215,7 +215,7 @@ def handle_exit_web(signum, frame):
     sys.exit(0)
 
 # Initialize the web thread
-web_thread = WebThread(port=12000)
+web_thread = WebThread(port=8000)
 
 # Set up signal handling for graceful shutdown
 signal.signal(signal.SIGINT, handle_exit_web)


### PR DESCRIPTION
…vice

- Changed port from 12000 back to 8000 in webapp.py
- This ensures compatibility with existing bjorn.service configuration
- Web interface should now be accessible on standard port 8000